### PR TITLE
changed notification position

### DIFF
--- a/app/assets/stylesheets/components/_sidebar.scss
+++ b/app/assets/stylesheets/components/_sidebar.scss
@@ -49,9 +49,9 @@
 
 .notification {
   position: absolute;
-  top: 5px;
+  top: -4px;
   // top: calc(50% - 12px);
-  right: 5px;
+  right: -4px;
   padding: 1px 8px;
   // width: 30px;
   // height: 30px;


### PR DESCRIPTION
changed the location of notification because I noticed for some people it was overlying with the text in some instances
<img width="226" alt="Screen Shot 2021-06-09 at 17 24 26" src="https://user-images.githubusercontent.com/57023406/121323070-cca52700-c90f-11eb-8e2a-92866cbb53bf.png">
